### PR TITLE
update libretile to vr 2.5

### DIFF
--- a/io.gitlab.celleron56.libretile.yaml
+++ b/io.gitlab.celleron56.libretile.yaml
@@ -92,5 +92,5 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/celleron56/libretile.git
-        commit: 6dd4b42f46530de4b8fdb0f40633f39bde11a3f1
+        commit: 0db5bb72f1aced70b5a97c5a78ffe84ed6a8fd35
    


### PR DESCRIPTION
this updates the version of libretile to 2.5
changing the modding system to be able to just use relative texturepath in mods + survival mode